### PR TITLE
docs: clarify on asyncio tasks implicitly started via query_once()

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -240,6 +240,7 @@ resolving the services which are currently available on the connected network.
 ```python
 async ServiceDiscovery.query_once(protocol: str, service: str, timeout: float = None) -> "Iterable[ServiceResponse]"
 ```
+***Note:** Despite the call being named `query_once()`, it starts asyncio tasks which keep running -- and querying -- after the call returned. To actually stop respective background tasks, `client.stop()` needs to be called.*
 
 Asks the service discovery to resolve the `protocol`/`service` combination once. After the passed `timeout` (or a default one) has passed return all services which have been identified in between.
 


### PR DESCRIPTION
Clarification implications when calling `query_once()`

Relates to / Fixes https://github.com/cbrand/micropython-mdns/issues/25