### PR TITLE
Add multicast membership again after reconnecting network

### DIFF
--- a/src/mdns_client/client.py
+++ b/src/mdns_client/client.py
@@ -60,12 +60,17 @@ class Client:
             loop.create_task(self.start())
         return callback_config
 
+    def add_membership(self, sock=None) -> None:
+        if sock is None:
+            sock = self.socket
+        member_info = dotted_ip_to_bytes(MDNS_ADDR) + dotted_ip_to_bytes(self.local_addr)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, member_info)
+
     def _make_socket(self) -> socket.socket:
         self.dprint("Creating socket for address %s" % (self.local_addr))
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        member_info = dotted_ip_to_bytes(MDNS_ADDR) + dotted_ip_to_bytes(self.local_addr)
-        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, member_info)
+        self.add_membership(sock)
         sock.setblocking(False)
         self.dprint("Socket creation finished")
         return sock

--- a/src/mdns_client/client.py
+++ b/src/mdns_client/client.py
@@ -56,7 +56,6 @@ class Client:
         self.callbacks[callback_config.id] = callback_config
         if self.stopped:
             self.dprint("Added consumer on stopped mdns client. Starting it now.")
-            self.stopped = False
             loop = uasyncio.get_event_loop()
             loop.create_task(self.start())
         return callback_config
@@ -72,9 +71,9 @@ class Client:
         return sock
 
     async def start(self) -> None:
-        self.stopped = False
-        self._init_socket()
-        await self.consume()
+        if self.stopped:
+            self.stopped = False
+            await self.consume()
 
     def _init_socket(self) -> None:
         self._close_socket()
@@ -92,6 +91,8 @@ class Client:
         self.socket = None
 
     async def consume(self) -> None:
+        self.dprint("Starting mdns client consume loop.")
+        self._init_socket()
         while not self.stopped:
             await self.process_waiting_data()
             await uasyncio.sleep_ms(100)


### PR DESCRIPTION
Until now, there was no easy way for the user to explicitly restore the multicast membership of the mDNS client socket. Also, repeated calls of `Client.start()` could unintentionally create multiple tasks/handlers. Both issues lead to incorrect service discovery under typical embedded scenarios.

After a network link state change, `client.add_membership()` can now be called without arguments to receive mDNS packets again.

And Client.start() now prevents to start multiple tasks and is now synchronous like all start() and stop() methods in other classes. Existing calls with await need to be adapted accordingly. However, the examples and most users will take advantage of the fact that `Client.add_callback()`, `ServiceDiscovery.query/query_once()` and `Responder.advertise()` implicitly start the client if necessary.

This PR is related to issue #36 