### PR TITLE
Fix for stricter encoding names in latest MicroPython: UTF-8 → utf-8

### DIFF
--- a/src/mdns_client/util.py
+++ b/src/mdns_client/util.py
@@ -33,7 +33,7 @@ def check_name(n: str) -> "List[bytes]":
         n = n.split(".")
         if n[-1] == "":
             n = n[:-1]
-    n = [i.encode("UTF-8") if isinstance(i, str) else i for i in n]
+    n = [i.encode("utf-8") if isinstance(i, str) else i for i in n]
     return n
 
 


### PR DESCRIPTION
Since some commits were merged on 2026-07-20 MicroPython treats encoding names more strict:
Now only "utf-8", "utf8" or "ascii" are valid - **lower-case!**

micropython/micropython@11d002be
micropython/micropython@a62626a5
micropython/micropython@ba9ea94 ← docs and tests

This bug will cause a LookupError at runtime with latest MicroPython:
```
>>> "test".encode("UTF-8")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
LookupError: unknown encoding: UTF-8
>>> "test".encode("utf-8")
b'test'
```

This fix won't break compatibility to older MicroPython versions.